### PR TITLE
Query Improvements

### DIFF
--- a/include/cblend_query.hpp
+++ b/include/cblend_query.hpp
@@ -273,13 +273,13 @@ enum class QueryError
 class Query final
 {
 public:
-    [[nodiscard]] static Result<Query, QueryError> Create(std::span<std::string_view> tokens);
-
+    [[nodiscard]] static Result<Query, QueryError> Create(std::span<const QueryToken> tokens);
+    [[nodiscard]] static Result<Query, QueryError> Create(std::span<const std::string_view> tokens);
     template<QueryString Input>
     [[nodiscard]] static Result<Query, QueryError> Create()
     {
         using Tokenizer = Tokenize<"[].", TokenizeBehavior::AnyOfDelimiter | TokenizeBehavior::SkipEmpty>;
-        auto tokens = ToTypes<std::string_view, Input, Tokenizer>();
+        const auto tokens = ToTypes<std::string_view, Input, Tokenizer>();
         return Create(std::span{ tokens.data(), tokens.size() });
     }
 

--- a/source/cblend.cpp
+++ b/source/cblend.cpp
@@ -170,7 +170,7 @@ bool cblend::BlendType::operator==(const BlendType& other) const
             {
                 const usize element_offset = *index * element_size;
 
-                if (!data.empty() && element_offset + element_size > data.size())
+                if (type->IsArray() && !data.empty() && element_offset + element_size > data.size())
                 {
                     return MakeError(QueryValueError::IndexOutOfBounds);
                 }

--- a/source/cblend_query.cpp
+++ b/source/cblend_query.cpp
@@ -52,7 +52,6 @@ using namespace cblend;
     return result;
 };
 
-
 Result<Query, QueryError> Query::Create(std::span<const QueryToken> tokens)
 {
     Query result = {};

--- a/source/cblend_query.cpp
+++ b/source/cblend_query.cpp
@@ -52,7 +52,26 @@ using namespace cblend;
     return result;
 };
 
-Result<Query, QueryError> Query::Create(std::span<std::string_view> tokens)
+
+Result<Query, QueryError> Query::Create(std::span<const QueryToken> tokens)
+{
+    Query result = {};
+    result.m_Tokens.reserve(tokens.size());
+
+    for (const auto& token : tokens)
+    {
+        result.m_Tokens.push_back(token);
+    }
+
+    if (result.m_Tokens.empty())
+    {
+        return MakeError(QueryError::InvalidQueryString);
+    }
+
+    return result;
+}
+
+Result<Query, QueryError> Query::Create(std::span<const std::string_view> tokens)
 {
     Query result = {};
     result.m_Tokens.reserve(tokens.size());


### PR DESCRIPTION
Allow creating queries from std::span<const QueryToken>, Query::Create now uses const spans, allow unsafe indexing on pointer types